### PR TITLE
Update #periscope_default_scope for Rails 5

### DIFF
--- a/lib/periscope/adapters/active_record.rb
+++ b/lib/periscope/adapters/active_record.rb
@@ -9,7 +9,7 @@ module Periscope
       private
 
       def periscope_default_scope
-        ::ActiveRecord::VERSION::MAJOR == 4 ? all : scoped
+        ::ActiveRecord::VERSION::MAJOR >= 4 ? all : scoped
       end
     end
   end

--- a/periscope-activerecord.gemspec
+++ b/periscope-activerecord.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name    = "periscope-activerecord"
-  gem.version = "2.1.0"
+  gem.version = "2.2.0"
 
   gem.author   = "Steve Richert"
   gem.email    = "steve.richert@gmail.com"
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.homepage = "https://github.com/laserlemon/periscope"
   gem.license  = "MIT"
 
-  gem.add_dependency "activerecord", ">= 3", "< 5"
+  gem.add_dependency "activerecord", ">= 3", "< 6"
   gem.add_dependency "periscope", "~> 2.1.0"
 
   gem.files = %w(


### PR DESCRIPTION
Like Rails 4, Rails 5 doesn't include the `scoped` method and requires a default scope of `all`.

I'm not sure how you want to manage the versioning. I bumped the minor number on `periscope-activerecord`, but not any of the other gems. It looks like you keep the rest of the versions in sync, so perhaps everybody gets to be `2.1`.